### PR TITLE
Returned example to original state, pylintrc updated

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -156,7 +156,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=board
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/examples/max7219_simpletest.py
+++ b/examples/max7219_simpletest.py
@@ -1,12 +1,12 @@
 import time
-from board import TX, RX, D1
+from board import TX, RX, A1
 import busio
 import digitalio
 from adafruit_max7219 import matrices
 
 mosi = TX
 clk = RX
-cs = digitalio.DigitalInOut(D1)
+cs = digitalio.DigitalInOut(A1)
 
 spi = busio.SPI(clk, MOSI=mosi)
 

--- a/examples/showbcddigits.py
+++ b/examples/showbcddigits.py
@@ -1,13 +1,13 @@
 import time
 import random
-from board import TX, RX, D1
+from board import TX, RX, A1
 import busio
 import digitalio
 from adafruit_max7219 import bcddigits
 
 mosi = TX
 clk = RX
-cs = digitalio.DigitalInOut(D1)
+cs = digitalio.DigitalInOut(A1)
 
 spi = busio.SPI(clk, MOSI=mosi)
 


### PR DESCRIPTION
Added `board` to ignored modules. Returned example to original state.