### PR TITLE
Update max7219.py

### DIFF
--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -57,7 +57,7 @@ Implementation Notes
 import digitalio
 from adafruit_bus_device import spi_device
 from micropython import const
-import framebuf
+import adafruit_framebuf as framebuf
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MAX7219.git"


### PR DESCRIPTION
Supports now the new (Adafruit_CircuitPython_framebuf)[https://github.com/adafruit/Adafruit_CircuitPython_framebuf] lib.