### PR TITLE
Type Annotations

### DIFF
--- a/adafruit_max7219/bcddigits.py
+++ b/adafruit_max7219/bcddigits.py
@@ -9,6 +9,13 @@
 from micropython import const
 from adafruit_max7219 import max7219
 
+try:
+    import digitalio
+    import busio
+    from typing import List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MAX7219.git"
 
@@ -23,16 +30,16 @@ class BCDDigits(max7219.MAX7219):
     Basic support for display on a 7-Segment BCD display controlled
     by a Max7219 chip using SPI.
 
-    :param object spi: an spi busio or spi bitbangio object
+    :param ~busio.SPI spi: an spi busio or spi bitbangio object
     :param ~digitalio.DigitalInOut cs: digital in/out to use as chip select signal
     :param int nDigits: number of led 7-segment digits; default 1; max 8
     """
 
-    def __init__(self, spi, cs, nDigits=1):
+    def __init__(self, spi: busio.SPI, cs: digitalio.DigitalInOut, nDigits: int = 1):
         self._ndigits = nDigits
         super().__init__(self._ndigits, 8, spi, cs)
 
-    def init_display(self):
+    def init_display(self) -> None:
 
         for cmd, data in (
             (_SHUTDOWN, 0),
@@ -46,7 +53,7 @@ class BCDDigits(max7219.MAX7219):
         self.clear_all()
         self.show()
 
-    def set_digit(self, dpos, value):
+    def set_digit(self, dpos: int, value: int) -> None:
         """
         Display one digit.
 
@@ -59,30 +66,30 @@ class BCDDigits(max7219.MAX7219):
             self.pixel(dpos, i, value & 0x01)
             value >>= 1
 
-    def set_digits(self, start, values):
+    def set_digits(self, start: int, values: List[int]) -> None:
         """
         Display digits from a list.
 
-        :param int s: digit to start display zero-based
-        :param list ds: list of integer values ranging from 0->15
+        :param int start: digit to start display zero-based
+        :param list[int] values: list of integer values ranging from 0->15
         """
         for value in values:
             # print('set digit {} start {}'.format(d,start))
             self.set_digit(start, value)
             start += 1
 
-    def show_dot(self, dpos, bit_value=None):
+    def show_dot(self, dpos: int, bit_value: int = None) -> None:
         """
         The decimal point for a digit.
 
         :param int dpos: the digit to set the decimal point zero-based
-        :param int value: value > zero lights the decimal point, else unlights the point
+        :param int bit_value: value > zero lights the decimal point, else unlights the point
         """
         if 0 <= dpos < self._ndigits:
             # print('set dot {} = {}'.format((self._ndigits - d -1),col))
             self.pixel(self._ndigits - dpos - 1, 7, bit_value)
 
-    def clear_all(self):
+    def clear_all(self) -> None:
         """
         Clear all digits and decimal points.
         """
@@ -90,12 +97,12 @@ class BCDDigits(max7219.MAX7219):
         for i in range(self._ndigits):
             self.show_dot(i)
 
-    def show_str(self, start, strg):
+    def show_str(self, start: int, strg: str) -> None:
         """
         Displays a numeric str in the display.  Shows digits ``0-9``, ``-``, and ``.``.
 
         :param int start: start position to show the numeric string
-        :param string str: the numeric string
+        :param str strg: the numeric string
         """
         cpos = start
         for char in strg:
@@ -111,7 +118,7 @@ class BCDDigits(max7219.MAX7219):
             self.set_digit(cpos, value)
             cpos += 1
 
-    def show_help(self, start):
+    def show_help(self, start: int) -> None:
         """
         Display the word HELP in the display.
 

--- a/adafruit_max7219/bcddigits.py
+++ b/adafruit_max7219/bcddigits.py
@@ -10,9 +10,10 @@ from micropython import const
 from adafruit_max7219 import max7219
 
 try:
+    # Used only for typing
+    from typing import List
     import digitalio
     import busio
-    from typing import List
 except ImportError:
     pass
 

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -9,6 +9,12 @@
 from micropython import const
 from adafruit_max7219 import max7219
 
+try:
+    import digitalio
+    import busio
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MAX7219.git"
 
@@ -22,14 +28,14 @@ class Matrix8x8(max7219.MAX7219):
     """
     Driver for a 8x8 LED matrix based on the MAX7219 chip.
 
-    :param object spi: an spi busio or spi bitbangio object
+    :param ~busio.SPI spi: an spi busio or spi bitbangio object
     :param ~digitalio.DigitalInOut cs: digital in/out to use as chip select signal
     """
 
-    def __init__(self, spi, cs):
+    def __init__(self, spi: busio.SPI, cs: digitalio.DigitalInOut):
         super().__init__(8, 8, spi, cs)
 
-    def init_display(self):
+    def init_display(self) -> None:
         for cmd, data in (
             (_SHUTDOWN, 0),
             (_DISPLAYTEST, 0),
@@ -42,18 +48,18 @@ class Matrix8x8(max7219.MAX7219):
         self.fill(0)
         self.show()
 
-    def text(self, strg, xpos, ypos, bit_value=1):
+    def text(self, strg: str, xpos: int, ypos: int, bit_value: int = 1) -> None:
         """
         Draw text in the 8x8 matrix.
 
+        :param str strg: string to place in to display
         :param int xpos: x position of LED in matrix
         :param int ypos: y position of LED in matrix
-        :param string strg: string to place in to display
-        :param bit_value: > 1 sets the text, otherwise resets
+        :param int bit_value: > 1 sets the text, otherwise resets
         """
         self.framebuf.text(strg, xpos, ypos, bit_value)
 
-    def clear_all(self):
+    def clear_all(self) -> None:
         """
         Clears all matrix leds.
         """

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -10,6 +10,7 @@ from micropython import const
 from adafruit_max7219 import max7219
 
 try:
+    # Used only for typing
     import digitalio
     import busio
 except ImportError:

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -11,6 +11,7 @@ from adafruit_max7219 import max7219
 
 try:
     # Used only for typing
+    import typing  # pylint: disable=unused-import
     import digitalio
     import busio
 except ImportError:

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -44,6 +44,7 @@ from micropython import const
 import adafruit_framebuf as framebuf
 
 try:
+    # Used only for typing
     import busio
 except ImportError:
     pass

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -37,11 +37,16 @@ Implementation Notes
 **Notes:**
 #.  Datasheet: https://cdn-shop.adafruit.com/datasheets/MAX7219.pdf
 """
-# MicroPython SSD1306 OLED driver, I2C and SPI interfaces
+# MicroPython MAX7219 driver, SPI interfaces
 import digitalio
 from adafruit_bus_device import spi_device
 from micropython import const
 import adafruit_framebuf as framebuf
+
+try:
+    import busio
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MAX7219.git"
@@ -57,15 +62,23 @@ class MAX7219:
 
     :param int width: the number of pixels wide
     :param int height: the number of pixels high
-    :param object spi: an spi busio or spi bitbangio object
+    :param ~busio.SPI spi: an spi busio or spi bitbangio object
     :param ~digitalio.DigitalInOut chip_select: digital in/out to use as chip select signal
-    :param baudrate: for SPIDevice baudrate (default 8000000)
-    :param polarity: for SPIDevice polarity (default 0)
-    :param phase: for SPIDevice phase (default 0)
+    :param int baudrate: for SPIDevice baudrate (default 8000000)
+    :param int polarity: for SPIDevice polarity (default 0)
+    :param int phase: for SPIDevice phase (default 0)
     """
 
     def __init__(
-        self, width, height, spi, cs, *, baudrate=8000000, polarity=0, phase=0
+        self,
+        width: int,
+        height: int,
+        spi: busio.SPI,
+        cs: digitalio.DigitalInOut,
+        *,
+        baudrate: int = 8000000,
+        polarity: int = 0,
+        phase: int = 0
     ):
 
         self._chip_select = cs
@@ -83,10 +96,10 @@ class MAX7219:
 
         self.init_display()
 
-    def init_display(self):
+    def init_display(self) -> None:
         """Must be implemented by derived class (``matrices``, ``bcddigits``)"""
 
-    def brightness(self, value):
+    def brightness(self, value: int) -> None:
         """
         Controls the brightness of the display.
 
@@ -96,14 +109,14 @@ class MAX7219:
             raise ValueError("Brightness out of range")
         self.write_cmd(_INTENSITY, value)
 
-    def show(self):
+    def show(self) -> None:
         """
         Updates the display.
         """
         for ypos in range(8):
             self.write_cmd(_DIGIT0 + ypos, self._buffer[ypos])
 
-    def fill(self, bit_value):
+    def fill(self, bit_value: int) -> None:
         """
         Fill the display buffer.
 
@@ -111,22 +124,27 @@ class MAX7219:
         """
         self.framebuf.fill(bit_value)
 
-    def pixel(self, xpos, ypos, bit_value=None):
+    def pixel(self, xpos: int, ypos: int, bit_value: int = None) -> None:
         """
         Set one buffer bit
 
-        :param xpos: x position to set bit
-        :param ypos: y position to set bit
+        :param int xpos: x position to set bit
+        :param int ypos: y position to set bit
         :param int bit_value: value > 0 sets the buffer bit, else clears the buffer bit
         """
         bit_value = 0x01 if bit_value else 0x00
         self.framebuf.pixel(xpos, ypos, bit_value)
 
-    def scroll(self, delta_x, delta_y):
-        """Srcolls the display using delta_x,delta_y."""
+    def scroll(self, delta_x: int, delta_y: int) -> None:
+        """
+        Srcolls the display using delta_x,delta_y.
+
+        :param int delta_x: positions to scroll in the x direction
+        :param int delta_y: positions to scroll in the y direction
+        """
         self.framebuf.scroll(delta_x, delta_y)
 
-    def write_cmd(self, cmd, data):
+    def write_cmd(self, cmd, data) -> None:
         # pylint: disable=no-member
         """Writes a command to spi device."""
         # print('cmd {} data {}'.format(cmd,data))

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -45,6 +45,7 @@ import adafruit_framebuf as framebuf
 
 try:
     # Used only for typing
+    import typing  # pylint: disable=unused-import
     import busio
 except ImportError:
     pass

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -146,9 +146,13 @@ class MAX7219:
         """
         self.framebuf.scroll(delta_x, delta_y)
 
-    def write_cmd(self, cmd, data) -> None:
-        # pylint: disable=no-member
-        """Writes a command to spi device."""
+    def write_cmd(self, cmd: int, data: int) -> None:
+        """
+        Writes a command to spi device.
+
+        :param int cmd: register address to write data to
+        :param int data: data to be written to commanded register
+        """
         # print('cmd {} data {}'.format(cmd,data))
         self._chip_select.value = False
         with self._spi_device as my_spi_device:


### PR DESCRIPTION
Implements type annotations as described by #34:
- [x] adafruit_max7219/max7219.py:67
- [x] adafruit_max7219/max7219.py:89
- [x] adafruit_max7219/max7219.py:106
- [x] adafruit_max7219/max7219.py:114
- [x] adafruit_max7219/max7219.py:125
- [x] adafruit_max7219/max7219.py:129
- [x] adafruit_max7219/matrices.py:29
- [x] adafruit_max7219/matrices.py:45
- [x] adafruit_max7219/bcddigits.py:31
- [x] adafruit_max7219/bcddigits.py:49
- [x] adafruit_max7219/bcddigits.py:62
- [x] adafruit_max7219/bcddigits.py:74
- [x] adafruit_max7219/bcddigits.py:93
- [x] adafruit_max7219/bcddigits.py:114

As I was going through adding types, I also updated the docstrings to match the function call.