### PR TITLE
Cascading Matrices

### DIFF
--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-`adafruit_max7219.matrices.Matrix8x8`
-`adafruit_max7219.matrices.CustomMatrix`
+`adafruit_max7219.matrices`
 ====================================================
 """
 from micropython import const

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -81,11 +81,19 @@ class CustomMatrix(max7219.ChainableMAX7219):
 
     def _calculate_y_coordinate_offsets(self):
         y_chunks = []
-        for _ in range((self.chain_length * 8) // self.width):
+        for _ in range(self.chain_length // (self.width // 8)):
             y_chunks.append([])
+        chunk = 0
+        chunk_size = 0
         for index in range(self.chain_length * 8):
-            chunk = index % ((self.chain_length * 8) // self.width)
             y_chunks[chunk].append(index)
+            chunk_size += 1
+            if chunk_size >= (self.width // 8):
+                chunk_size = 0
+                chunk += 1
+                if chunk >= len(y_chunks):
+                    chunk = 0
+
         y_index = []
         for chunk in y_chunks:
             y_index += chunk
@@ -131,6 +139,5 @@ class CustomMatrix(max7219.ChainableMAX7219):
         """
 
         buffer_y = xpos // 8 + self.y_index[ypos * self.y_offset]
-        buffer_x = xpos % 8
-
+        buffer_x = (xpos - ((xpos // 8) * 8)) % 8
         return super().pixel(buffer_x, buffer_y, bit_value=bit_value)

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -58,3 +58,79 @@ class Matrix8x8(max7219.MAX7219):
         Clears all matrix leds.
         """
         self.fill(0)
+
+
+class CustomMatrix(max7219.ChainableMAX7219):
+    """
+    Driver for a custom 8x8 LED matrix constellation based on daisy chained MAX7219 chips.
+
+    :param object spi: an spi busio or spi bitbangio object
+    :param ~digitalio.DigitalInOut cs: digital in/out to use as chip select signal
+    :param int width: the number of pixels wide
+    :param int height: the number of pixels high
+    :param int rotation: the number of times to rotate the coordinate system (default 1)
+    """
+
+    def __init__(self, spi, cs, width, height, *, rotation=1):
+        super().__init__(width, height, spi, cs)
+
+        self.y_offset = width // 8
+        self.y_index = self._calculate_y_coordinate_offsets()
+
+        self.framebuf.rotation = rotation
+
+    def _calculate_y_coordinate_offsets(self):
+        y_chunks = []
+        for _ in range((self.chain_length * 8) // self.width):
+            y_chunks.append([])
+        for index in range(self.chain_length * 8):
+            chunk = index % ((self.chain_length * 8) // self.width)
+            y_chunks[chunk].append(index)
+        y_index = []
+        for chunk in y_chunks:
+            y_index += chunk
+        return y_index
+
+    def init_display(self):
+        for cmd, data in (
+            (_SHUTDOWN, 0),
+            (_DISPLAYTEST, 0),
+            (_SCANLIMIT, 7),
+            (_DECODEMODE, 0),
+            (_SHUTDOWN, 1),
+        ):
+            self.write_cmd(cmd, data)
+
+        self.fill(0)
+        self.show()
+
+    def text(self, strg, xpos, ypos, bit_value=1):
+        """
+        Draw text in the 8x8 matrix.
+
+        :param int xpos: x position of LED in matrix
+        :param int ypos: y position of LED in matrix
+        :param string strg: string to place in to display
+        :param bit_value: > 1 sets the text, otherwise resets
+        """
+        self.framebuf.text(strg, xpos, ypos, bit_value)
+
+    def clear_all(self):
+        """
+        Clears all matrix leds.
+        """
+        self.fill(0)
+
+    def pixel(self, xpos, ypos, bit_value=None):
+        """
+        Set one buffer bit
+
+        :param xpos: x position to set bit
+        :param ypos: y position to set bit
+        :param int bit_value: value > 0 sets the buffer bit, else clears the buffer bit
+        """
+
+        buffer_y = xpos // 8 + self.y_index[ypos * self.y_offset]
+        buffer_x = xpos % 8
+
+        return super().pixel(buffer_x, buffer_y, bit_value=bit_value)

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -72,14 +72,22 @@ class CustomMatrix(max7219.ChainableMAX7219):
     """
     Driver for a custom 8x8 LED matrix constellation based on daisy chained MAX7219 chips.
 
-    :param object spi: an spi busio or spi bitbangio object
+    :param ~busio.SPI spi: an spi busio or spi bitbangio object
     :param ~digitalio.DigitalInOut cs: digital in/out to use as chip select signal
     :param int width: the number of pixels wide
     :param int height: the number of pixels high
     :param int rotation: the number of times to rotate the coordinate system (default 1)
     """
 
-    def __init__(self, spi, cs, width, height, *, rotation=1):
+    def __init__(
+        self,
+        spi: busio.SPI,
+        cs: digitalio.DigitalInOut,
+        width: int,
+        height: int,
+        *,
+        rotation: int = 1
+    ):
         super().__init__(width, height, spi, cs)
 
         self.y_offset = width // 8
@@ -87,7 +95,7 @@ class CustomMatrix(max7219.ChainableMAX7219):
 
         self.framebuf.rotation = rotation
 
-    def _calculate_y_coordinate_offsets(self):
+    def _calculate_y_coordinate_offsets(self) -> None:
         y_chunks = []
         for _ in range(self.chain_length // (self.width // 8)):
             y_chunks.append([])
@@ -107,7 +115,7 @@ class CustomMatrix(max7219.ChainableMAX7219):
             y_index += chunk
         return y_index
 
-    def init_display(self):
+    def init_display(self) -> None:
         for cmd, data in (
             (_SHUTDOWN, 0),
             (_DISPLAYTEST, 0),
@@ -120,29 +128,29 @@ class CustomMatrix(max7219.ChainableMAX7219):
         self.fill(0)
         self.show()
 
-    def text(self, strg, xpos, ypos, bit_value=1):
+    def text(self, strg: str, xpos: int, ypos: int, bit_value: int = 1) -> None:
         """
-        Draw text in the 8x8 matrix.
+        Draw text in the matrix.
 
+        :param str strg: string to place in to display
         :param int xpos: x position of LED in matrix
         :param int ypos: y position of LED in matrix
-        :param string strg: string to place in to display
-        :param bit_value: > 1 sets the text, otherwise resets
+        :param int bit_value: > 1 sets the text, otherwise resets
         """
         self.framebuf.text(strg, xpos, ypos, bit_value)
 
-    def clear_all(self):
+    def clear_all(self) -> None:
         """
         Clears all matrix leds.
         """
         self.fill(0)
 
-    def pixel(self, xpos, ypos, bit_value=None):
+    def pixel(self, xpos: int, ypos: int, bit_value: int = None) -> None:
         """
         Set one buffer bit
 
-        :param xpos: x position to set bit
-        :param ypos: y position to set bit
+        :param int xpos: x position to set bit
+        :param int ypos: y position to set bit
         :param int bit_value: value > 0 sets the buffer bit, else clears the buffer bit
         """
 

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: 2017 Dan Halbert for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 Daniel Flanagan
 #
 # SPDX-License-Identifier: MIT
 
 """
 `adafruit_max7219.matrices.Matrix8x8`
+`adafruit_max7219.matrices.CustomMatrix`
 ====================================================
 """
 from micropython import const
@@ -137,6 +139,7 @@ class CustomMatrix(max7219.ChainableMAX7219):
         """
         self.fill(0)
 
+    # pylint: disable=inconsistent-return-statements
     def pixel(self, xpos: int, ypos: int, bit_value: int = None) -> None:
         """
         Set one buffer bit
@@ -145,6 +148,8 @@ class CustomMatrix(max7219.ChainableMAX7219):
         :param int ypos: y position to set bit
         :param int bit_value: value > 0 sets the buffer bit, else clears the buffer bit
         """
+        if xpos < 0 or ypos < 0 or xpos >= self.width or ypos >= self.height:
+            return
         buffer_x, buffer_y = self._pixel_coords_to_framebuf_coords(xpos, ypos)
         return super().pixel(buffer_x, buffer_y, bit_value=bit_value)
 

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -128,17 +128,6 @@ class CustomMatrix(max7219.ChainableMAX7219):
         self.fill(0)
         self.show()
 
-    def text(self, strg: str, xpos: int, ypos: int, bit_value: int = 1) -> None:
-        """
-        Draw text in the matrix.
-
-        :param str strg: string to place in to display
-        :param int xpos: x position of LED in matrix
-        :param int ypos: y position of LED in matrix
-        :param int bit_value: > 1 sets the text, otherwise resets
-        """
-        self.framebuf.text(strg, xpos, ypos, bit_value)
-
     def clear_all(self) -> None:
         """
         Clears all matrix leds.

--- a/adafruit_max7219/matrices.py
+++ b/adafruit_max7219/matrices.py
@@ -161,6 +161,52 @@ class CustomMatrix(max7219.ChainableMAX7219):
             ypos * self.y_offset
         ]
 
+    def _get_pixel(self, xpos: int, ypos: int) -> int:
+        """
+        Get value of a matrix pixel
+
+        :param int xpos: x position
+        :param int ypos: y position
+        :return: value of pixel in matrix
+        :rtype: int
+        """
+        x, y = self._pixel_coords_to_framebuf_coords(xpos, ypos)
+        buffer_value = self._buffer[-1 * y - 1]
+        return ((buffer_value & 2 ** x) >> x) & 1
+
+    # Adafruit Circuit Python Framebuf Scroll Function
+    # Authors: Kattni Rembor, Melissa LeBlanc-Williams and Tony DiCola, for Adafruit Industries
+    # License: MIT License (https://opensource.org/licenses/MIT)
+    def scroll(self, delta_x: int, delta_y: int) -> None:
+        """
+        Srcolls the display using delta_x, delta_y.
+
+        :param int delta_x: positions to scroll in the x direction
+        :param int delta_y: positions to scroll in the y direction
+        """
+        if delta_x < 0:
+            shift_x = 0
+            xend = self.width + delta_x
+            dt_x = 1
+        else:
+            shift_x = self.width - 1
+            xend = delta_x - 1
+            dt_x = -1
+        if delta_y < 0:
+            y = 0
+            yend = self.height + delta_y
+            dt_y = 1
+        else:
+            y = self.height - 1
+            yend = delta_y - 1
+            dt_y = -1
+        while y != yend:
+            x = shift_x
+            while x != xend:
+                self.pixel(x, y, self._get_pixel(x - delta_x, y - delta_y))
+                x += dt_x
+            y += dt_y
+
     def rect(
         self, x: int, y: int, width: int, height: int, color: int, fill: bool = False
     ) -> None:

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -6,6 +6,7 @@
 
 """
 `adafruit_max7219.max7219` - MAX7219 LED Matrix/Digit Display Driver
+`adafruit_max7219.ChainableMAX7219` - Chained MAX7219 LED Matrix/Digit Display Driver
 ========================================================================
 CircuitPython library to support MAX7219 LED Matrix/Digit Display Driver.
 This library supports the use of the MAX7219-based display in CircuitPython,

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -6,7 +6,6 @@
 
 """
 `adafruit_max7219.max7219` - MAX7219 LED Matrix/Digit Display Driver
-`adafruit_max7219.ChainableMAX7219` - Chained MAX7219 LED Matrix/Digit Display Driver
 ========================================================================
 CircuitPython library to support MAX7219 LED Matrix/Digit Display Driver.
 This library supports the use of the MAX7219-based display in CircuitPython,

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -165,15 +165,23 @@ class ChainableMAX7219(MAX7219):
 
     :param int width: the number of pixels wide
     :param int height: the number of pixels high
-    :param object spi: an spi busio or spi bitbangio object
+    :param ~busio.SPI spi: an spi busio or spi bitbangio object
     :param ~digitalio.DigitalInOut chip_select: digital in/out to use as chip select signal
-    :param baudrate: for SPIDevice baudrate (default 8000000)
-    :param polarity: for SPIDevice polarity (default 0)
-    :param phase: for SPIDevice phase (default 0)
+    :param int baudrate: for SPIDevice baudrate (default 8000000)
+    :param int polarity: for SPIDevice polarity (default 0)
+    :param int phase: for SPIDevice phase (default 0)
     """
 
     def __init__(
-        self, width, height, spi, cs, *, baudrate=8000000, polarity=0, phase=0
+        self,
+        width: int,
+        height: int,
+        spi: busio.SPI,
+        cs: digitalio.DigitalInOut,
+        *,
+        baudrate: int = 8000000,
+        polarity: int = 0,
+        phase: int = 0
     ):
         self.chain_length = (height // 8) * (width // 8)
 
@@ -183,16 +191,20 @@ class ChainableMAX7219(MAX7219):
         self._buffer = bytearray(self.chain_length * 8)
         self.framebuf = framebuf.FrameBuffer1(self._buffer, self.chain_length * 8, 8)
 
-    def write_cmd(self, cmd, data):
-        # pylint: disable=no-member
-        """Writes a command to spi device."""
+    def write_cmd(self, cmd: int, data: int) -> None:
+        """
+        Writes a command to spi device.
+
+        :param int cmd: register address to write data to
+        :param int data: data to be written to commanded register
+        """
         # print('cmd {} data {}'.format(cmd,data))
         self._chip_select.value = False
         with self._spi_device as my_spi_device:
             for _ in range(self.chain_length):
                 my_spi_device.write(bytearray([cmd, data]))
 
-    def show(self):
+    def show(self) -> None:
         """
         Updates the display.
         """

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2016 Philip R. Moyer  for Adafruit Industries
 # SPDX-FileCopyrightText: 2016 Radomir Dopieralski for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 Daniel Flanagan
 #
 # SPDX-License-Identifier: MIT
 
@@ -13,6 +14,7 @@ either an 8x8 matrix or a 8 digit 7-segment numeric display.
 See Also
 =========
 * matrices.Maxtrix8x8 is a class support an 8x8 led matrix display
+* matrices.CustomMatrix is a class support a custom sized constellation of 8x8 led matrix displays
 * bcddigits.BCDDigits is a class that support the 8 digit 7-segment display
 
 Beware that most CircuitPython compatible hardware are 3.3v logic level! Make
@@ -60,7 +62,7 @@ _INTENSITY = const(10)
 
 class MAX7219:
     """
-    MAX2719 - driver for displays based on max719 chip_select
+    MAX7219 - driver for displays based on max7219 chip_select
 
     :param int width: the number of pixels wide
     :param int height: the number of pixels high
@@ -161,7 +163,7 @@ class MAX7219:
 
 class ChainableMAX7219(MAX7219):
     """
-    Daisy Chainable MAX2719 - driver for cascading displays based on max719 chip_select
+    Daisy Chainable MAX7219 - driver for cascading displays based on max7219 chip_select
 
     :param int width: the number of pixels wide
     :param int height: the number of pixels high

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,6 +3,7 @@
 
 .. automodule:: adafruit_max7219.max7219
    :members:
+   :show-inheritance:
 
 .. automodule:: adafruit_max7219.matrices
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ extensions = [
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
 autodoc_mock_imports = ["framebuf"]
+autodoc_member_order = "bysource"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -10,3 +10,7 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/max7219_showbcddigits.py
     :caption: examples/max7219_showbcddigits.py
     :linenos:
+
+.. literalinclude:: ../examples/max7219_custommatrixtest.py
+    :caption: examples/max7219_custommatrixtest.py
+    :linenos:

--- a/examples/max7219_custommatrixtest.py
+++ b/examples/max7219_custommatrixtest.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2021 Daniel Flanagan
+# SPDX-License-Identifier: MIT
+
+import time
+from board import TX, RX, A1
+import busio
+import digitalio
+from adafruit_max7219 import matrices
+
+mosi = TX
+clk = RX
+cs = digitalio.DigitalInOut(A1)
+
+spi = busio.SPI(clk, MOSI=mosi)
+
+matrix = matrices.CustomMatrix(spi, cs, 32, 8)
+while True:
+    print("Cycle Start")
+    # all lit up
+    matrix.fill(True)
+    matrix.show()
+    time.sleep(0.5)
+
+    # all off
+    matrix.fill(False)
+    matrix.show()
+    time.sleep(0.5)
+
+    # snake across panel
+    for y in range(8):
+        for x in range(32):
+            if not y % 2:
+                matrix.pixel(x, y, 1)
+            else:
+                matrix.pixel(31 - x, y, 1)
+            matrix.show()
+            time.sleep(0.05)
+
+    # show a string one character at a time
+    adafruit = "Adafruit"
+    matrix.fill(0)
+    for i, char in enumerate(adafruit[:3]):
+        matrix.text(char, i * 6, 0)
+        matrix.show()
+        time.sleep(1.0)
+    matrix.fill(0)
+    for i, char in enumerate(adafruit[3:]):
+        matrix.text(char, i * 6, 0)
+        matrix.show()
+        time.sleep(1.0)
+
+    # scroll the last character off the display
+    for i in range(32):
+        matrix.scroll(-1, 0)
+        matrix.show()
+        time.sleep(0.25)
+
+    # scroll a string across the display
+    for pixel_position in range(len(adafruit) * 8):
+        matrix.fill(0)
+        matrix.text(adafruit, -pixel_position, 0)
+        matrix.show()
+        time.sleep(0.25)


### PR DESCRIPTION
The MAX7219 supports chaining multiple chips in series, this pull request adds support for that functionality and implements a class for a chain of 8x8 LED matrices.

## `adafruit_max7219.max7219.ChainableMAX7219` 
Adds chainable support by modifying [this RPi Pico MicroPython  implementation](https://github.com/stechiez/raspberrypi-pico/blob/main/pico_max7219/max7219.py) to work as a subclass of `max7219` in the CircuitPython ecosystem.

## `adafruit_max7219.matrices.CustomMatrix` 
A feature matched `adafruit_max7219.matrices.Matrix8x8` that allows for displays of any rectangular configuration of 8x8 LED matrices by implementing `ChainableMAX7219` and modifying relevant parts of the underlying `adafruit_framebuf` dependency.

### Hardware
I don't believe Adafruit carries any multi-panel 8x8 LED Matrices *(yet...)*, but they are abundant and affordable on Amazon.  I've been using [this one](https://www.amazon.com/dp/B088LWLHP5).

### Wiring
All LED Matrices need to be oriented the same way, and their driving MAX7219 chips should be chained left to right, top to bottom.  So if there are multiple rows, the last chip of the first row is chained to the first chip of the second row.

### Coordinate System
The top left pixel of the display is `(0, 0)`.  The `x` value increases from left to right while the `y` value increases from top to bottom.

### Demos
`examples/max7219_custommatrixtest.py` is a modified version of `examples/max7219_simpletest.py` for a set of 4 8x8 LED Matrices arranged as a single 32x8 display:
![32x8 MAX7219 Matrix Demo](https://media.giphy.com/media/hjWY4M7qeMzxrfzeu5/giphy.gif)

It's also possible to create displays with multiple rows of matrices:
![32x16 MAX7219 Matrix Demo](https://media.giphy.com/media/3ACYfSLEugekrwezf2/giphy.gif)