### PR TITLE
Make BCDDigits chainable

### DIFF
--- a/adafruit_max7219/bcddigits.py
+++ b/adafruit_max7219/bcddigits.py
@@ -47,10 +47,10 @@ class BCDDigits(max7219.ChainableMAX7219):
             (_SHUTDOWN, 0),
             (_DISPLAYTEST, 0),
             (_SCANLIMIT, 7),
-            (_DECODEMODE, (2**self._ndigits) - 1),
-            (_SHUTDOWN, 1),
         ):
             self.write_cmd(cmd, data)
+        self.write_cmd(_DECODEMODE, (2**self._ndigits) - 1, data_overflow=True)
+        self.write_cmd(_SHUTDOWN, 1)
 
         self.clear_all()
         self.show()

--- a/adafruit_max7219/bcddigits.py
+++ b/adafruit_max7219/bcddigits.py
@@ -26,14 +26,15 @@ _SHUTDOWN = const(12)
 _DISPLAYTEST = const(15)
 
 
-class BCDDigits(max7219.MAX7219):
+class BCDDigits(max7219.ChainableMAX7219):
     """
     Basic support for display on a 7-Segment BCD display controlled
     by a Max7219 chip using SPI.
 
     :param ~busio.SPI spi: an spi busio or spi bitbangio object
     :param ~digitalio.DigitalInOut cs: digital in/out to use as chip select signal
-    :param int nDigits: number of led 7-segment digits; default 1; max 8
+    :param int nDigits: number of led 7-segment digits; default 1; max 8 if one
+        MAX7219; max 16 if two MAX7219 are chained together
     """
 
     def __init__(self, spi: busio.SPI, cs: digitalio.DigitalInOut, nDigits: int = 1):
@@ -61,6 +62,15 @@ class BCDDigits(max7219.MAX7219):
         :param int dpos: the digit position; zero-based
         :param int value: integer ranging from 0->15
         """
+
+        if not 0 <= dpos < self.chain_length * 8:
+            raise ValueError(
+                "Digit with index {0} cannot be set with only {1} MAX7219(s)".format(
+                    dpos,
+                    self.chain_length,
+                )
+            )
+
         dpos = self._ndigits - dpos - 1
         for i in range(4):
             # print('digit {} pixel {} value {}'.format(dpos,i+4,v & 0x01))

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -210,6 +210,7 @@ class ChainableMAX7219(MAX7219):
                 byte_data = data
                 if data_overflow:
                     byte_data = data >> 8 * (self.chain_length - byte_num)
+                    byte_data &= 0xFF
                 my_spi_device.write(bytearray([cmd, byte_data]))
 
     def show(self) -> None:

--- a/adafruit_max7219/max7219.py
+++ b/adafruit_max7219/max7219.py
@@ -194,7 +194,7 @@ class ChainableMAX7219(MAX7219):
         self.framebuf = framebuf.FrameBuffer1(self._buffer, self.chain_length * 8, 8)
 
     # pylint: disable=arguments-differ
-    def write_cmd(self, cmd: int, data: int, data_overflow: bool = False) -> None:
+    def write_cmd(self, cmd: int, data: int, *, data_overflow: bool = False) -> None:
         """
         Writes a command to spi device.
 


### PR DESCRIPTION
Not tested.

Resolves #39 by changing inheritance of `BCDDigits` to `ChainableMAX7219`.  Also adds a value check to notify if a digit is ever out of range.